### PR TITLE
Bump to `0.5.1`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "language-pegjs",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "language-pegjs",
-      "version": "0.5.0",
+      "version": "0.5.1",
+      "license": "MIT",
       "engines": {
         "atom": "*",
         "node": "*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-pegjs",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "PEG.js language support in Pulsar",
   "engines": {
     "atom": "*",


### PR DESCRIPTION
Like the title says, bump the version of this package, to allow a Pulsar tagged release to update on the backend.