### PR TITLE
delete .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-*.cache
-node_modules


### PR DESCRIPTION
This removes the `.gitignore` since it has no effect.
There is no `node_modules` directors since there are no dependencies.
And the `*.cache` are most likely came from coffeelint which was removed.